### PR TITLE
Fix bug: bot message is empty

### DIFF
--- a/app/public/src/js/components/SlackMessage.js
+++ b/app/public/src/js/components/SlackMessage.js
@@ -48,7 +48,7 @@ export default React.createClass({
     };
     let botMessage = (message, showChannel) => {
       let attachment = _.find(message.attachments, (attachment) => attachment.text);
-      let text = attachment ? attachment.text : '';
+      let text = attachment ? attachment.text : message.text;
       let icon = message.icons ? message.icons.image_48 : (attachment ? attachment.author_icon : '');
       return (
         <div className="slack-message">


### PR DESCRIPTION
When ["Bots"](https://slack.com/apps/A0F7YS25R-bots) _says_ something, the react app can't catch message.  Fixed.