### PR TITLE
Format all *.js files with prettier

### DIFF
--- a/viewer/front/actions/SlackActions.js
+++ b/viewer/front/actions/SlackActions.js
@@ -1,13 +1,13 @@
-import SlackConstants from '../constants/SlackConstants';
-import MessagesType from '../constants/MessagesType';
-import { push } from 'react-router-redux'
-import 'whatwg-fetch'
+import SlackConstants from "../constants/SlackConstants";
+import MessagesType from "../constants/MessagesType";
+import { push } from "react-router-redux";
+import "whatwg-fetch";
 
-const generateApiUrl = (url) => url + '?t=' + (new Date()).getTime();
+const generateApiUrl = url => url + "?t=" + new Date().getTime();
 
 // callback becomes callable if it is passed to this function last time
 let _lastCallback;
-const callableIfLast = (callback) => {
+const callableIfLast = callback => {
   _lastCallback = callback;
   return (...args) => {
     if (_lastCallback === callback) {
@@ -18,7 +18,7 @@ const callableIfLast = (callback) => {
 
 const fetchJSON = (url, params) => {
   const defaultParam = {
-    credentials: 'same-origin'
+    credentials: "same-origin"
   };
   params = Object.assign(defaultParam, params);
   return fetch(url, params).then(res => res.json());
@@ -26,34 +26,31 @@ const fetchJSON = (url, params) => {
 
 export default {
   getChannels() {
-    return dispatch => (
-      fetchJSON(generateApiUrl('channels.json')).then((channels) => {
+    return dispatch =>
+      fetchJSON(generateApiUrl("channels.json")).then(channels => {
         dispatch({
           type: SlackConstants.UPDATE_CHANNELS,
           channels
         });
-      })
-    );
+      });
   },
   getIms() {
-    return dispatch => (
-      fetchJSON(generateApiUrl('ims.json')).then((ims) => {
+    return dispatch =>
+      fetchJSON(generateApiUrl("ims.json")).then(ims => {
         dispatch({
           type: SlackConstants.UPDATE_IMS,
           ims
         });
-      })
-    );
+      });
   },
   getUsers() {
-    return dispatch => (
-      fetchJSON(generateApiUrl('users.json')).then((users) => {
+    return dispatch =>
+      fetchJSON(generateApiUrl("users.json")).then(users => {
         dispatch({
           type: SlackConstants.UPDATE_USERS,
           users
         });
-      })
-    );
+      });
   },
   getAroundMessages(channel, ts) {
     return dispatch => {
@@ -61,24 +58,30 @@ export default {
         type: SlackConstants.START_UPDATE_MESSAGES
       });
 
-      const updateMessage = callableIfLast(({ messages, has_more_past_message: hasMorePastMessage, has_more_future_message: hasMoreFutureMessage }) => {
-        dispatch({
-          type: SlackConstants.UPDATE_MESSAGES,
+      const updateMessage = callableIfLast(
+        ({
           messages,
-          hasMorePastMessage,
-          hasMoreFutureMessage,
-          messagesInfo: {
-            type: MessagesType.CHANNEL_MESSAGES,
-            channel
-          }
-        });
-      });
+          has_more_past_message: hasMorePastMessage,
+          has_more_future_message: hasMoreFutureMessage
+        }) => {
+          dispatch({
+            type: SlackConstants.UPDATE_MESSAGES,
+            messages,
+            hasMorePastMessage,
+            hasMoreFutureMessage,
+            messagesInfo: {
+              type: MessagesType.CHANNEL_MESSAGES,
+              channel
+            }
+          });
+        }
+      );
 
-      const url = generateApiUrl('around_messages/' + channel + '.json');
+      const url = generateApiUrl("around_messages/" + channel + ".json");
       const params = {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
         },
         body: `ts=${ts}` // TODO: post as json format
       };
@@ -91,61 +94,66 @@ export default {
         type: SlackConstants.START_UPDATE_MESSAGES
       });
 
-      const updateMessage = callableIfLast(({ messages, has_more_message: hasMoreMessage }) => {
-        dispatch({
-          type: SlackConstants.UPDATE_MESSAGES,
-          messages,
-          hasMorePastMessage: hasMoreMessage,
-          messagesInfo: {
-            type: MessagesType.CHANNEL_MESSAGES,
-            channel
-          }
-        });
-      });
+      const updateMessage = callableIfLast(
+        ({ messages, has_more_message: hasMoreMessage }) => {
+          dispatch({
+            type: SlackConstants.UPDATE_MESSAGES,
+            messages,
+            hasMorePastMessage: hasMoreMessage,
+            messagesInfo: {
+              type: MessagesType.CHANNEL_MESSAGES,
+              channel
+            }
+          });
+        }
+      );
 
-      const url = generateApiUrl('messages/' + channel + '.json');
+      const url = generateApiUrl("messages/" + channel + ".json");
       const params = {
-        method: 'POST'
+        method: "POST"
       };
       fetchJSON(url, params).then(updateMessage);
     };
   },
   getMoreMessages(channel, { isPast, limitTs }) {
     return dispatch => {
-      const updateMessage = callableIfLast(({ messages, has_more_message: hasMoreMessage }) => {
-        dispatch({
-          type: isPast ? SlackConstants.UPDATE_MORE_PAST_MESSAGES : SlackConstants.UPDATE_MORE_FUTURE_MESSAGES,
-          messages,
-          hasMoreMessage
-        });
-      });
+      const updateMessage = callableIfLast(
+        ({ messages, has_more_message: hasMoreMessage }) => {
+          dispatch({
+            type: isPast
+              ? SlackConstants.UPDATE_MORE_PAST_MESSAGES
+              : SlackConstants.UPDATE_MORE_FUTURE_MESSAGES,
+            messages,
+            hasMoreMessage
+          });
+        }
+      );
 
-      const url = generateApiUrl('messages/' + channel + '.json');
+      const url = generateApiUrl("messages/" + channel + ".json");
       const params = {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' // TODO: post as json format
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" // TODO: post as json format
         },
-        body: `${isPast ? 'max_ts' : 'min_ts'}=${limitTs}`
+        body: `${isPast ? "max_ts" : "min_ts"}=${limitTs}`
       };
       fetchJSON(url, params).then(updateMessage);
     };
   },
   getTeamInfo() {
-    return (dispatch) => (
-      fetchJSON(generateApiUrl('team.json')).then((teamInfo) => {
+    return dispatch =>
+      fetchJSON(generateApiUrl("team.json")).then(teamInfo => {
         dispatch({
           type: SlackConstants.UPDATE_TEAM_INFO,
           teamInfo
         });
-      })
-    );
+      });
   },
   importBackup(formData) {
     return dispatch => {
-      const url = generateApiUrl('import_backup');
+      const url = generateApiUrl("import_backup");
       fetchJSON(url, {
-        method: 'post',
+        method: "post",
         body: formData
       });
     };
@@ -159,23 +167,25 @@ export default {
         type: SlackConstants.START_UPDATE_MESSAGES
       });
 
-      const updateMessage = callableIfLast(({ messages, has_more_message: hasMoreMessage }) => {
-        dispatch({
-          type: SlackConstants.UPDATE_MESSAGES,
-          messages,
-          hasMorePastMessage: hasMoreMessage,
-          messagesInfo: {
-            type: MessagesType.SEARCH_MESSAGES,
-            searchWord: word
-          }
-        });
-      });
+      const updateMessage = callableIfLast(
+        ({ messages, has_more_message: hasMoreMessage }) => {
+          dispatch({
+            type: SlackConstants.UPDATE_MESSAGES,
+            messages,
+            hasMorePastMessage: hasMoreMessage,
+            messagesInfo: {
+              type: MessagesType.SEARCH_MESSAGES,
+              searchWord: word
+            }
+          });
+        }
+      );
 
-      const url = generateApiUrl('search');
+      const url = generateApiUrl("search");
       const params = {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
         },
         body: `word=${encodeURIComponent(word)}` // TODO: post json format
       };
@@ -184,21 +194,27 @@ export default {
   },
   searchMore(word, { isPast, limitTs }) {
     return dispatch => {
-      const updateMessage = callableIfLast(({ messages, has_more_message: hasMoreMessage }) => {
-        dispatch({
-          type: isPast ? SlackConstants.UPDATE_MORE_PAST_MESSAGES : SlackConstants.UPDATE_MORE_FUTURE_MESSAGES,
-          messages,
-          hasMoreMessage,
-        });
-      });
+      const updateMessage = callableIfLast(
+        ({ messages, has_more_message: hasMoreMessage }) => {
+          dispatch({
+            type: isPast
+              ? SlackConstants.UPDATE_MORE_PAST_MESSAGES
+              : SlackConstants.UPDATE_MORE_FUTURE_MESSAGES,
+            messages,
+            hasMoreMessage
+          });
+        }
+      );
 
-      const url = generateApiUrl('search');
+      const url = generateApiUrl("search");
       const params = {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
         },
-        body: `word=${encodeURIComponent(word)}&${isPast ? 'max_ts' : 'min_ts'}=${limitTs}` // TODO: post json format
+        body: `word=${encodeURIComponent(word)}&${
+          isPast ? "max_ts" : "min_ts"
+        }=${limitTs}` // TODO: post json format
       };
       fetchJSON(url, params).then(updateMessage);
     };

--- a/viewer/front/app.js
+++ b/viewer/front/app.js
@@ -1,23 +1,28 @@
-import React from 'react';
-import { render } from 'react-dom';
+import React from "react";
+import { render } from "react-dom";
 
-import { Provider } from 'react-redux';
-import { createStore, combineReducers, applyMiddleware } from 'redux';
-import thunkMiddleware from 'redux-thunk';
+import { Provider } from "react-redux";
+import { createStore, combineReducers, applyMiddleware } from "redux";
+import thunkMiddleware from "redux-thunk";
 
-import createHistory from 'history/createBrowserHistory';
-import { Route } from 'react-router';
-import { ConnectedRouter, routerReducer, routerMiddleware, push } from 'react-router-redux';
+import createHistory from "history/createBrowserHistory";
+import { Route } from "react-router";
+import {
+  ConnectedRouter,
+  routerReducer,
+  routerMiddleware,
+  push
+} from "react-router-redux";
 
-import reducers from './reducers';
-import SlackPatron from './components/SlackPatron';
-import SlackActions from './actions/SlackActions';
+import reducers from "./reducers";
+import SlackPatron from "./components/SlackPatron";
+import SlackActions from "./actions/SlackActions";
 
-import 'normalize.css/normalize.css';
-import './app.less';
+import "normalize.css/normalize.css";
+import "./app.less";
 
 const history = createHistory({
-  basename: document.getElementById('basename').getAttribute('href')
+  basename: document.getElementById("basename").getAttribute("href")
 });
 const middleware = routerMiddleware(history);
 
@@ -38,5 +43,5 @@ render(
       <SlackPatron />
     </ConnectedRouter>
   </Provider>,
-  document.getElementById('app')
+  document.getElementById("app")
 );

--- a/viewer/front/components/ChannelMessagesHeader.js
+++ b/viewer/front/components/ChannelMessagesHeader.js
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux'
-import _ from 'lodash';
-import ChannelName from './ChannelName'
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import _ from "lodash";
+import ChannelName from "./ChannelName";
 
 const ChannelMessagesHeader = ({ channels, ims, currentChannelId }) => {
   const allChannels = Object.assign({}, channels, ims);
-  const channel = _.find(allChannels, (c) => c.id === currentChannelId);
+  const channel = _.find(allChannels, c => c.id === currentChannelId);
 
   if (!channel) {
     return null;

--- a/viewer/front/components/ChannelMessagesSection.js
+++ b/viewer/front/components/ChannelMessagesSection.js
@@ -1,19 +1,25 @@
-import React from 'react';
-import { connect } from 'react-redux'
-import ChannelMessagesHeader from './ChannelMessagesHeader';
-import MessagesList from './MessagesList';
-import SlackActions from '../actions/SlackActions';
+import React from "react";
+import { connect } from "react-redux";
+import ChannelMessagesHeader from "./ChannelMessagesHeader";
+import MessagesList from "./MessagesList";
+import SlackActions from "../actions/SlackActions";
 
 class ChannelMessagesSection extends React.Component {
   componentDidMount() {
-    this.initialzeData(this.props.match.params.channel, this.props.match.params.ts);
+    this.initialzeData(
+      this.props.match.params.channel,
+      this.props.match.params.ts
+    );
   }
   componentWillReceiveProps(nextProps) {
     if (
       this.props.match.params.channel !== nextProps.match.params.channel ||
       this.props.match.params.ts !== nextProps.match.params.ts
     ) {
-      this.initialzeData(nextProps.match.params.channel, nextProps.match.params.ts);
+      this.initialzeData(
+        nextProps.match.params.channel,
+        nextProps.match.params.ts
+      );
     }
   }
   initialzeData(channel, ts) {
@@ -23,8 +29,11 @@ class ChannelMessagesSection extends React.Component {
     const channel = this.props.match.params.channel;
     return (
       <div className="channel-messages">
-        <ChannelMessagesHeader currentChannelId={ channel } />
-        <MessagesList scrollToTs={this.props.match.params.ts} onLoadMoreMessages={this.props.loadMoreChannelMessages(channel)} />
+        <ChannelMessagesHeader currentChannelId={channel} />
+        <MessagesList
+          scrollToTs={this.props.match.params.ts}
+          onLoadMoreMessages={this.props.loadMoreChannelMessages(channel)}
+        />
       </div>
     );
   }
@@ -50,4 +59,6 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(ChannelMessagesSection);
+export default connect(mapStateToProps, mapDispatchToProps)(
+  ChannelMessagesSection
+);

--- a/viewer/front/components/ChannelName.js
+++ b/viewer/front/components/ChannelName.js
@@ -1,18 +1,18 @@
-import React from 'react';
+import React from "react";
 
-import './ChannelName.less';
+import "./ChannelName.less";
 
 const channelTypeToClassName = {
-  C: 'channel',
-  G: 'group',
-  D: 'im'
+  C: "channel",
+  G: "group",
+  D: "im"
 };
 
 export default class extends React.Component {
   render() {
     const channel = this.props.channel;
     const channelType = channel.id[0];
-    const classNames = ['channel-name', channelTypeToClassName[channelType]];
-    return <span className={classNames.join(' ')}>{channel.name}</span>;
+    const classNames = ["channel-name", channelTypeToClassName[channelType]];
+    return <span className={classNames.join(" ")}>{channel.name}</span>;
   }
 }

--- a/viewer/front/components/ConfigureWindow.js
+++ b/viewer/front/components/ConfigureWindow.js
@@ -1,15 +1,15 @@
-import React from 'react';
-import { connect } from 'react-redux'
-import SlackActions from '../actions/SlackActions';
+import React from "react";
+import { connect } from "react-redux";
+import SlackActions from "../actions/SlackActions";
 
-import './ConfigureWindow.less';
+import "./ConfigureWindow.less";
 
 class ConfigureWindow extends React.Component {
   importBackup(e) {
     e.preventDefault();
     const formData = new FormData(this.refs.importBackup);
     this.props.importBackup(formData);
-    this.refs.backupFile.value = '';
+    this.refs.backupFile.value = "";
   }
   render() {
     return (
@@ -18,18 +18,39 @@ class ConfigureWindow extends React.Component {
           <div className="configure-section">
             <p className="section-title">Import Slack Backup File</p>
             <p>Import a Slack backup file</p>
-            <p>You can download Slack backup file from <a href={`https://${this.props.teamInfo.domain}.slack.com/services/export`} target="_blank">this page</a>(You need administrator privileges)</p>
-            <form id="import-slack-backup-form" onSubmit={this.importBackup.bind(this)} ref="importBackup">
+            <p>
+              You can download Slack backup file from{" "}
+              <a
+                href={`https://${
+                  this.props.teamInfo.domain
+                }.slack.com/services/export`}
+                target="_blank"
+              >
+                this page
+              </a>(You need administrator privileges)
+            </p>
+            <form
+              id="import-slack-backup-form"
+              onSubmit={this.importBackup.bind(this)}
+              ref="importBackup"
+            >
               <div className="form-section">
                 <input type="file" name="file" ref="backupFile" />
               </div>
               <div className="form-section">
-                <input className="submit-button" type="submit" value="Import backup file" />
+                <input
+                  className="submit-button"
+                  type="submit"
+                  value="Import backup file"
+                />
               </div>
             </form>
           </div>
         </div>
-        <div className="configure-background" onClick={this.props.toggleConfigureWindow}></div>
+        <div
+          className="configure-background"
+          onClick={this.props.toggleConfigureWindow}
+        />
       </div>
     );
   }
@@ -42,7 +63,7 @@ const mapStateToProps = state => {
 };
 const mapDispatchToProps = dispatch => {
   return {
-    importBackup: (formData) => {
+    importBackup: formData => {
       dispatch(SlackActions.importBackup(formData));
     }
   };

--- a/viewer/front/components/MessagesList.js
+++ b/viewer/front/components/MessagesList.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import { connect } from 'react-redux'
-import $ from 'jquery';
-import SlackMessage from './SlackMessage';
+import React from "react";
+import { connect } from "react-redux";
+import $ from "jquery";
+import SlackMessage from "./SlackMessage";
 
 class MessagesList extends React.Component {
   constructor(props) {
@@ -29,8 +29,11 @@ class MessagesList extends React.Component {
     this.previousHeight = this.currentHeight();
     this.previousTop = $(this.refs.messagesList).scrollTop();
 
-    const oldestTs = (this.props.messages.length > 0) && this.props.messages[0].ts;
-    const latestTs = (this.props.messages.length > 0) && this.props.messages[this.props.messages.length - 1].ts;
+    const oldestTs =
+      this.props.messages.length > 0 && this.props.messages[0].ts;
+    const latestTs =
+      this.props.messages.length > 0 &&
+      this.props.messages[this.props.messages.length - 1].ts;
     this.props.onLoadMoreMessages({
       isPast,
       limitTs: isPast ? oldestTs : latestTs
@@ -47,9 +50,7 @@ class MessagesList extends React.Component {
           this.currentHeight() - (this.previousHeight || 0)
         );
       } else {
-        $(this.refs.messagesList).scrollTop(
-          (this.previousTop || 0)
-        );
+        $(this.refs.messagesList).scrollTop(this.previousTop || 0);
       }
       this.scrollBackAfterUpdate = false;
     }
@@ -70,13 +71,19 @@ class MessagesList extends React.Component {
   componentWillReceiveProps(nextProps) {
     // TODO: create reducer which manage scroll state
     // loading more
-    if (this.state.isLoadingMore && nextProps.messages !== this.props.messages) {
+    if (
+      this.state.isLoadingMore &&
+      nextProps.messages !== this.props.messages
+    ) {
       this.scrollBackAfterUpdate = true;
       this.setState({ isLoadingMore: false });
     }
 
     // first view
-    if (nextProps.messagesInfo !== this.props.messagesInfo || nextProps.scrollToTs !== this.props.scrollToTs) {
+    if (
+      nextProps.messagesInfo !== this.props.messagesInfo ||
+      nextProps.scrollToTs !== this.props.scrollToTs
+    ) {
       if (this.props.scrollToTs) {
         this.scrollToTsAfterUpdate = true;
       } else {
@@ -87,17 +94,21 @@ class MessagesList extends React.Component {
   render() {
     this.tsToNode = {};
 
-    const createMessages = (messages) => messages.map(message => (
-        <SlackMessage message={message} users={this.props.users}
+    const createMessages = messages =>
+      messages.map(message => (
+        <SlackMessage
+          message={message}
+          users={this.props.users}
           teamInfo={this.props.teamInfo}
           channels={this.props.channels}
           ims={this.props.ims}
           key={message.ts}
           type={this.props.messagesInfo.type}
           selected={message.ts === this.props.scrollToTs}
-          messageRef={ n => this.tsToNode[message.ts] = n } />
+          messageRef={n => (this.tsToNode[message.ts] = n)}
+        />
       ));
-    const loadMoreSection = (isPast) => {
+    const loadMoreSection = isPast => {
       if (isPast && !this.props.hasMorePastMessage) {
         return;
       }
@@ -109,7 +120,10 @@ class MessagesList extends React.Component {
         return <div className="messages-load-more loading">Loading...</div>;
       } else {
         return (
-          <div className="messages-load-more" onClick={this.handleLoadMore.bind(this, isPast)}>
+          <div
+            className="messages-load-more"
+            onClick={this.handleLoadMore.bind(this, isPast)}
+          >
             Load more messages...
           </div>
         );

--- a/viewer/front/components/MessagesSection.js
+++ b/viewer/front/components/MessagesSection.js
@@ -1,22 +1,22 @@
-import React from 'react';
-import { connect } from 'react-redux'
-import { Route, Switch } from 'react-router';
-import SearchMessagesSection from './SearchMessagesSection';
-import ChannelMessagesSection from './ChannelMessagesSection';
+import React from "react";
+import { connect } from "react-redux";
+import { Route, Switch } from "react-router";
+import SearchMessagesSection from "./SearchMessagesSection";
+import ChannelMessagesSection from "./ChannelMessagesSection";
 
-import './MessagesSection.less';
+import "./MessagesSection.less";
 
 const MessagesSection = ({ isMessageLoading }) => (
   <div className="messages">
-    { isMessageLoading ? (
-        <div className="loading-messages">
-          <h2 className="title">Now loading...</h2>
-        </div>
-      ) : null }
+    {isMessageLoading ? (
+      <div className="loading-messages">
+        <h2 className="title">Now loading...</h2>
+      </div>
+    ) : null}
     <Switch>
-      <Route path="/search/:searchWord" component={ SearchMessagesSection } />
-      <Route path="/:channel/:ts" component={ ChannelMessagesSection } />
-      <Route path="/:channel" component={ ChannelMessagesSection } />
+      <Route path="/search/:searchWord" component={SearchMessagesSection} />
+      <Route path="/:channel/:ts" component={ChannelMessagesSection} />
+      <Route path="/:channel" component={ChannelMessagesSection} />
     </Switch>
   </div>
 );

--- a/viewer/front/components/SearchForm.js
+++ b/viewer/front/components/SearchForm.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import { connect } from 'react-redux'
-import { Route, Switch } from 'react-router';
-import SlackActions from '../actions/SlackActions';
+import React from "react";
+import { connect } from "react-redux";
+import { Route, Switch } from "react-router";
+import SlackActions from "../actions/SlackActions";
 
-import './SearchForm.less';
+import "./SearchForm.less";
 
 class SearchForm extends React.Component {
   onSearch(e) {
@@ -12,11 +12,18 @@ class SearchForm extends React.Component {
     this.props.updateSearchWord(this.refs.search.value);
   }
   render() {
-    const searchWord = this.props.match ? this.props.match.params.searchWord : '';
+    const searchWord = this.props.match
+      ? this.props.match.params.searchWord
+      : "";
     return (
       <div className="search-form-wrapper">
         <form className="search-form" onSubmit={this.onSearch.bind(this)}>
-          <input type="search" ref="search" defaultValue={searchWord} placeholder="Search" />
+          <input
+            type="search"
+            ref="search"
+            defaultValue={searchWord}
+            placeholder="Search"
+          />
         </form>
       </div>
     );

--- a/viewer/front/components/SearchMessagesSection.js
+++ b/viewer/front/components/SearchMessagesSection.js
@@ -1,14 +1,16 @@
-import React from 'react';
-import { connect } from 'react-redux'
-import MessagesList from './MessagesList';
-import SlackActions from '../actions/SlackActions';
+import React from "react";
+import { connect } from "react-redux";
+import MessagesList from "./MessagesList";
+import SlackActions from "../actions/SlackActions";
 
 class SearchMessagesSection extends React.Component {
   componentDidMount() {
     this.initialzeData(this.props.match.params.searchWord);
   }
   componentWillReceiveProps(nextProps) {
-    if (this.props.match.params.searchWord !== nextProps.match.params.searchWord) {
+    if (
+      this.props.match.params.searchWord !== nextProps.match.params.searchWord
+    ) {
       this.initialzeData(nextProps.match.params.searchWord);
     }
   }
@@ -21,7 +23,7 @@ class SearchMessagesSection extends React.Component {
     return (
       <div className="search-messages">
         <div className="messages-header">
-          <div className="title">Search: { searchWord }</div>
+          <div className="title">Search: {searchWord}</div>
         </div>
         <MessagesList onLoadMoreMessages={loadMoreSearchMessages(searchWord)} />
       </div>
@@ -45,4 +47,6 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(SearchMessagesSection);
+export default connect(mapStateToProps, mapDispatchToProps)(
+  SearchMessagesSection
+);

--- a/viewer/front/components/Sidebar.js
+++ b/viewer/front/components/Sidebar.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
-import SidebarHeader from './SidebarHeader';
-import SlackChannels from './SlackChannels';
+import React, { Component } from "react";
+import SidebarHeader from "./SidebarHeader";
+import SlackChannels from "./SlackChannels";
 
-import './Sidebar.less';
+import "./Sidebar.less";
 
 export default () => (
   <div className="sidebar">

--- a/viewer/front/components/SidebarHeader.js
+++ b/viewer/front/components/SidebarHeader.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import { connect } from 'react-redux'
-import ConfigureWindow from './ConfigureWindow';
+import React from "react";
+import { connect } from "react-redux";
+import ConfigureWindow from "./ConfigureWindow";
 
 class SidebarHeader extends React.Component {
   constructor(props) {
@@ -18,15 +18,19 @@ class SidebarHeader extends React.Component {
     return (
       <div>
         <div className="sidebar-header">
-          <div className="team-info" onClick={this.toggleConfigureWindow.bind(this)}>
+          <div
+            className="team-info"
+            onClick={this.toggleConfigureWindow.bind(this)}
+          >
             <span className="team-name">{this.props.teamInfo.name}</span>
-            <p className="configure-toggler"></p>
+            <p className="configure-toggler" />
           </div>
         </div>
-        {
-          this.state.showConfigureWindow &&
-            <ConfigureWindow toggleConfigureWindow={this.toggleConfigureWindow.bind(this)} />
-        }
+        {this.state.showConfigureWindow && (
+          <ConfigureWindow
+            toggleConfigureWindow={this.toggleConfigureWindow.bind(this)}
+          />
+        )}
       </div>
     );
   }

--- a/viewer/front/components/SlackChannels.js
+++ b/viewer/front/components/SlackChannels.js
@@ -1,13 +1,14 @@
-import React from 'react';
-import { connect } from 'react-redux'
-import { NavLink } from 'react-router-dom';
-import { Route } from 'react-router';
-import ChannelName from './ChannelName';
+import React from "react";
+import { connect } from "react-redux";
+import { NavLink } from "react-router-dom";
+import { Route } from "react-router";
+import ChannelName from "./ChannelName";
 
 const SlackChannels = ({ channels, ims }) => {
-  const createChannelList = (channels) => Object.values(channels).map(channel => (
+  const createChannelList = channels =>
+    Object.values(channels).map(channel => (
       <li key={channel.id}>
-        <NavLink to={ `/${channel.id}` }>
+        <NavLink to={`/${channel.id}`}>
           <ChannelName channel={channel} />
         </NavLink>
       </li>
@@ -17,15 +18,11 @@ const SlackChannels = ({ channels, ims }) => {
     <div className="sidebar-body">
       <div className="slack-channels">
         <h3>CHANNELS({Object.keys(channels).length})</h3>
-        <ul className="list">
-          {createChannelList(channels)}
-        </ul>
+        <ul className="list">{createChannelList(channels)}</ul>
       </div>
       <div className="slack-ims">
         <h3>DIRECT MESSAGES({Object.keys(ims).length})</h3>
-        <ul className="list">
-          {createChannelList(ims)}
-        </ul>
+        <ul className="list">{createChannelList(ims)}</ul>
       </div>
     </div>
   );

--- a/viewer/front/components/SlackMessage.js
+++ b/viewer/front/components/SlackMessage.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
-import ChannelName from './ChannelName';
-import { Link } from 'react-router-dom';
-import MessagesType from '../constants/MessagesType';
+import React, { Component } from "react";
+import ChannelName from "./ChannelName";
+import { Link } from "react-router-dom";
+import MessagesType from "../constants/MessagesType";
 
 export default class extends Component {
   getChannel(id) {
@@ -22,27 +22,33 @@ export default class extends Component {
     return new Date(date * 1000).toLocaleString();
   }
   formatText(text) {
-    const entity = (str) => {
-      return str.replace(/"/g, "&quot;")
+    const entity = str => {
+      return str
+        .replace(/"/g, "&quot;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;");
     };
-    const channelLink = (id) => {
+    const channelLink = id => {
       const channel = this.getChannel(id);
       return `#${channel && channel.name}`;
     };
-    const userLink = (id) => {
+    const userLink = id => {
       const user = this.getUser(id);
       return `@${user && user.name}`;
     };
-    const specialCommand = (command) => `@${command}`;
-    const uriLink = (uri) => `<a href="${uri}" target="_blank">${uri}</a>`;
+    const specialCommand = command => `@${command}`;
+    const uriLink = uri => `<a href="${uri}" target="_blank">${uri}</a>`;
     if (text) {
-      return text.replace(/<#([0-9A-Za-z]+)>/, (m, id) => channelLink(id))
-        .replace(/<#([0-9A-Za-z]+)\|([0-9A-Za-z]+)>/gi, (m, id) => channelLink(id))
+      return text
+        .replace(/<#([0-9A-Za-z]+)>/, (m, id) => channelLink(id))
+        .replace(/<#([0-9A-Za-z]+)\|([0-9A-Za-z]+)>/gi, (m, id) =>
+          channelLink(id)
+        )
         .replace(/<@([0-9A-Za-z]+)>/gi, (m, id) => userLink(id))
         .replace(/<@([0-9A-Za-z]+)\|([0-9A-Za-z]+)>/gi, (m, id) => userLink(id))
-        .replace(/<!(channel|everyone|group)>/gi, (m, command) => specialCommand(command))
+        .replace(/<!(channel|everyone|group)>/gi, (m, command) =>
+          specialCommand(command)
+        )
         .replace(/<(https?:\/\/[^>]*)>/gi, (m, uri) => uriLink(entity(uri)));
     }
     return text;
@@ -51,24 +57,33 @@ export default class extends Component {
     return `/${message.channel}/${message.ts}`;
   }
   originalMessageLink(teamInfo, message) {
-    const messageId = message.ts.replace('.', '');
-    return `https://${teamInfo.domain}.slack.com/messages/${message.channel}/p${messageId}`;
+    const messageId = message.ts.replace(".", "");
+    return `https://${teamInfo.domain}.slack.com/messages/${
+      message.channel
+    }/p${messageId}`;
   }
   render() {
-    const createMarkup = (text) => {
+    const createMarkup = text => {
       return {
-        __html: this.formatText(text) || ''
+        __html: this.formatText(text) || ""
       };
     };
-    const SlackMessagePrototype = ({ message, icon, username, showChannel, teamInfo, text }) => {
+    const SlackMessagePrototype = ({
+      message,
+      icon,
+      username,
+      showChannel,
+      teamInfo,
+      text
+    }) => {
       const channel = this.getChannel(message.channel);
-      const classNames = ['slack-message'];
+      const classNames = ["slack-message"];
       if (this.props.selected) {
-        classNames.push('selected');
+        classNames.push("selected");
       }
 
       return (
-        <div className={ classNames.join(' ') } ref={this.props.messageRef}>
+        <div className={classNames.join(" ")} ref={this.props.messageRef}>
           <div className="slack-message-user-image">
             <img src={icon} />
           </div>
@@ -79,27 +94,42 @@ export default class extends Component {
                 {this.formatDate(message.ts)}
               </Link>
             </div>
-            { showChannel && channel ? (
-                <div className="slack-message-channel">
-                  <Link to={ `/${channel.id}` }>
-                    <ChannelName channel={channel} />
-                  </Link>
-                </div>
-              ) : null }
+            {showChannel && channel ? (
+              <div className="slack-message-channel">
+                <Link to={`/${channel.id}`}>
+                  <ChannelName channel={channel} />
+                </Link>
+              </div>
+            ) : null}
             <div className="slack-original-message-link">
-              <a href={this.originalMessageLink(teamInfo, message)} target="_blank">open original</a>
+              <a
+                href={this.originalMessageLink(teamInfo, message)}
+                target="_blank"
+              >
+                open original
+              </a>
             </div>
-            <div className="slack-message-text"
-              dangerouslySetInnerHTML={createMarkup(text)}></div>
+            <div
+              className="slack-message-text"
+              dangerouslySetInnerHTML={createMarkup(text)}
+            />
           </div>
         </div>
       );
     };
     const botMessage = (teamInfo, message, showChannel) => {
-      const attachment = _.find(message.attachments, (attachment) => attachment.text);
+      const attachment = _.find(
+        message.attachments,
+        attachment => attachment.text
+      );
       const text = attachment ? attachment.text : message.text;
-      const icon = message.icons ? message.icons.image_48 : (attachment ? attachment.author_icon : '');
-      return <SlackMessagePrototype
+      const icon = message.icons
+        ? message.icons.image_48
+        : attachment
+          ? attachment.author_icon
+          : "";
+      return (
+        <SlackMessagePrototype
           message={message}
           icon={icon}
           username={message.username}
@@ -107,9 +137,11 @@ export default class extends Component {
           teamInfo={teamInfo}
           text={text}
         />
+      );
     };
     const normalMessage = (teamInfo, message, user, showChannel) => {
-      return <SlackMessagePrototype
+      return (
+        <SlackMessagePrototype
           message={message}
           icon={user && user.profile.image_48}
           username={user && user.name}
@@ -117,6 +149,7 @@ export default class extends Component {
           teamInfo={teamInfo}
           text={message.text}
         />
+      );
     };
 
     if (this.props.message.hidden) {
@@ -126,11 +159,16 @@ export default class extends Component {
     const message = this.props.message;
     const showChannel = this.props.type === MessagesType.SEARCH_MESSAGES;
     switch (this.props.message.subtype) {
-      case 'bot_message':
+      case "bot_message":
         return botMessage(this.props.teamInfo, message, showChannel);
         break;
       default:
-        return normalMessage(this.props.teamInfo, message, this.getUser(message.user), showChannel);
+        return normalMessage(
+          this.props.teamInfo,
+          message,
+          this.getUser(message.user),
+          showChannel
+        );
         break;
     }
   }

--- a/viewer/front/components/SlackPatron.js
+++ b/viewer/front/components/SlackPatron.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import Sidebar from './Sidebar';
-import MessagesSection from './MessagesSection';
-import SearchForm from './SearchForm';
+import React from "react";
+import Sidebar from "./Sidebar";
+import MessagesSection from "./MessagesSection";
+import SearchForm from "./SearchForm";
 
 export default () => (
   <div className="slack-patron">

--- a/viewer/front/reducers/channels.js
+++ b/viewer/front/reducers/channels.js
@@ -1,4 +1,4 @@
-import SlackConstants from '../constants/SlackConstants';
+import SlackConstants from "../constants/SlackConstants";
 
 const channels = (state = { channels: [], ims: [] }, action) => {
   switch (action.type) {

--- a/viewer/front/reducers/index.js
+++ b/viewer/front/reducers/index.js
@@ -1,9 +1,9 @@
-import channels from './channels';
-import searchWord from './searchWord';
-import teamInfo from './teamInfo';
-import users from './users';
-import messages from './messages';
-import isMessageLoading from './isMessageLoading';
+import channels from "./channels";
+import searchWord from "./searchWord";
+import teamInfo from "./teamInfo";
+import users from "./users";
+import messages from "./messages";
+import isMessageLoading from "./isMessageLoading";
 
 const reducers = {
   channels,

--- a/viewer/front/reducers/isMessageLoading.js
+++ b/viewer/front/reducers/isMessageLoading.js
@@ -1,4 +1,4 @@
-import SlackConstants from '../constants/SlackConstants';
+import SlackConstants from "../constants/SlackConstants";
 
 const channels = (state = false, action) => {
   switch (action.type) {

--- a/viewer/front/reducers/messages.js
+++ b/viewer/front/reducers/messages.js
@@ -1,6 +1,14 @@
-import SlackConstants from '../constants/SlackConstants';
+import SlackConstants from "../constants/SlackConstants";
 
-const messages = (state = { messages: [], hasMorePastMessage: false, hasMoreFutureMessage: false, messagesInfo: {} }, action) => {
+const messages = (
+  state = {
+    messages: [],
+    hasMorePastMessage: false,
+    hasMoreFutureMessage: false,
+    messagesInfo: {}
+  },
+  action
+) => {
   switch (action.type) {
     case SlackConstants.UPDATE_MESSAGES:
       return {

--- a/viewer/front/reducers/searchWord.js
+++ b/viewer/front/reducers/searchWord.js
@@ -1,4 +1,4 @@
-import SlackConstants from '../constants/SlackConstants';
+import SlackConstants from "../constants/SlackConstants";
 
 const searchWord = (state = null, action) => {
   switch (action.type) {

--- a/viewer/front/reducers/teamInfo.js
+++ b/viewer/front/reducers/teamInfo.js
@@ -1,4 +1,4 @@
-import SlackConstants from '../constants/SlackConstants';
+import SlackConstants from "../constants/SlackConstants";
 
 const teamInfo = (state = {}, action) => {
   switch (action.type) {

--- a/viewer/front/reducers/users.js
+++ b/viewer/front/reducers/users.js
@@ -1,4 +1,4 @@
-import SlackConstants from '../constants/SlackConstants';
+import SlackConstants from "../constants/SlackConstants";
 
 const users = (state = {}, action) => {
   switch (action.type) {


### PR DESCRIPTION
I'm fully aware you might not agree with these changes, since [prettier](https://prettier.io/) is a opinionated code formatter.

But I have my editor set to format JS via it automatically, and figured I might as well see if you're willing to accept this before I start hacking on anything else :)

For what it's worth, everything still seems to work as intended.