### PR TITLE
limit count query size in viewer

### DIFF
--- a/viewer/viewer.rb
+++ b/viewer/viewer.rb
@@ -61,8 +61,7 @@ def messages(params)
   all_messages = Messages
     .find(condition)
     .sort(ts: ts_direction)
-    .limit(limit + 1)
-  has_more_message = all_messages.count > limit
+  has_more_message = all_messages.count({limit: limit+1}) > limit
   return_messages = all_messages.limit(limit).to_a
   return_messages = return_messages.reverse if ts_direction == -1
 


### PR DESCRIPTION
The count query has not been limited up to now, so that it took long time to respond.

```
slack-patron-viewer | D, [2019-04-17T10:06:02.413899 #1] DEBUG -- : MONGODB | mongo:27017 | slack_logger.count | STARTED | {"count"=>"messages", "query"=>{"hidden"=>{"$ne"=>true}, "channel"=>"C7XXXXXXX"}}
slack-patron-viewer | D, [2019-04-17T10:07:13.481522 #1] DEBUG -- : MONGODB | mongo:27017 | slack_logger.count | SUCCEEDED | 71.066540863s
```