### PR TITLE
fix unsatisfiable constraints error while building

### DIFF
--- a/logger/Dockerfile
+++ b/logger/Dockerfile
@@ -10,8 +10,8 @@ RUN set -x && \
 	apk add --update \
 		git \
 		build-base \
-		openssl \
-		openssl-dev && \
+		libressl \
+		libressl-dev && \
 	echo 'gem: --no-document' >> /etc/gemrc && \
 	git clone ${REPOSITORY} ${SRCDIR} && \
 	cd ${SRCDIR} && \


### PR DESCRIPTION
The logger build failed with the following error:

```
$ docker-compose build logger
Building logger
Step 1/9 : FROM ruby:2.4-alpine
 ---> 621114028aef
Step 2/9 : MAINTAINER tyage <namatyage@gmail.com>
 ---> Using cache
 ---> dc48db64d61d
Step 3/9 : ARG REPOSITORY="https://github.com/tyage/slack-patron.git"
 ---> Using cache
 ---> 0f58141069a2
Step 4/9 : ARG BRANCH="master"
 ---> Using cache
 ---> 8074e3d7b18b
Step 5/9 : ARG SRCDIR="/usr/local/slack-patron"
 ---> Using cache
 ---> 3cc7e6c4f42b
Step 6/9 : RUN set -x && 	apk upgrade --update && 	apk add --update 		git 		build-base 		openssl 		openssl-dev && 	echo 'gem: --no-document' >> /etc/gemrc && 	git clone ${REPOSITORY} ${SRCDIR} && 	cd ${SRCDIR} && 	git checkout ${BRANCH} && 	bundle install
 ---> Running in 71401a4e503f
+ apk upgrade --update
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
Upgrading critical system libraries and apk-tools:
(1/1) Upgrading apk-tools (2.9.1-r2 -> 2.10.1-r0)
Executing busybox-1.27.2-r11.trigger
Continuing the upgrade transaction with new apk-tools:
(1/7) Upgrading musl (1.1.18-r3 -> 1.1.18-r4)
(2/7) Upgrading ncurses-terminfo-base (6.0_p20171125-r0 -> 6.0_p20171125-r1)
(3/7) Upgrading ncurses-terminfo (6.0_p20171125-r0 -> 6.0_p20171125-r1)
(4/7) Upgrading ncurses-libs (6.0_p20171125-r0 -> 6.0_p20171125-r1)
(5/7) Upgrading bzip2 (1.0.6-r6 -> 1.0.6-r7)
(6/7) Upgrading ca-certificates (20171114-r0 -> 20190108-r0)
(7/7) Upgrading musl-utils (1.1.18-r3 -> 1.1.18-r4)
Executing busybox-1.27.2-r11.trigger
Executing ca-certificates-20190108-r0.trigger
OK: 30 MiB in 31 packages
+ apk add --update git build-base openssl openssl-dev
ERROR: unsatisfiable constraints:
  libressl-dev-2.6.5-r0:
    conflicts:
               openssl-dev-1.0.2t-r0[pc:libcrypto=2.6.5]
               openssl-dev-1.0.2t-r0[pc:libssl=2.6.5]
               openssl-dev-1.0.2t-r0[pc:openssl=2.6.5]
    satisfies: .ruby-rundeps-0[libressl-dev]
  openssl-dev-1.0.2t-r0:
    conflicts:
               libressl-dev-2.6.5-r0[pc:libcrypto=1.0.2t]
               libressl-dev-2.6.5-r0[pc:libssl=1.0.2t]
               libressl-dev-2.6.5-r0[pc:openssl=1.0.2t]
    satisfies: world[openssl-dev]
ERROR: Service 'logger' failed to build: The command '/bin/sh -c set -x && 	apk upgrade --update && 	apk add --update 		git 		build-base 		openssl 		openssl-dev && 	echo 'gem: --no-document' >> /etc/gemrc && 	git clone ${REPOSITORY} ${SRCDIR} && 	cd ${SRCDIR} && 	git checkout ${BRANCH} && 	bundle install' returned a non-zero code: 3
```

To resolve it, use LibreSSL instead of OpenSSL.