### PR TITLE
Switch ARG to ENV in Dockerfiles and persist DB storage

### DIFF
--- a/db/.gitignore
+++ b/db/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,5 @@ services:
 
   mongo:
     image: mongo
+    volumes:
+      - ./db:/data/db

--- a/logger/Dockerfile
+++ b/logger/Dockerfile
@@ -1,9 +1,9 @@
 FROM ruby:2.4-alpine
 LABEL maintainer="namatyage@gmail.com"
 
-ARG REPOSITORY="https://github.com/tyage/slack-patron.git"
-ARG BRANCH="master"
-ARG SRCDIR="/usr/local/slack-patron"
+ENV REPOSITORY="https://github.com/tyage/slack-patron.git"
+ENV BRANCH="master"
+ENV SRCDIR="/usr/local/slack-patron"
 
 RUN set -x && \
 	apk upgrade --update && \

--- a/viewer/Dockerfile
+++ b/viewer/Dockerfile
@@ -1,9 +1,9 @@
 FROM ruby:2.4-alpine
 LABEL maintainer="namatyage@gmail.com"
 
-ARG REPOSITORY="https://github.com/tyage/slack-patron.git"
-ARG BRANCH="master"
-ARG SRCDIR="/usr/local/slack-patron"
+ENV REPOSITORY="https://github.com/tyage/slack-patron.git"
+ENV BRANCH="master"
+ENV SRCDIR="/usr/local/slack-patron"
 
 RUN set -x && \
 	apk upgrade --update && \


### PR DESCRIPTION
Setting up the `logger` and `viewer` containers was failing because the setup script couldn't access the variables set using `ARG`. Using `ENV` fixed that. In addition, I have made the database volume persistent so the data can be accessed using other tools.