### PR TITLE
replace not only https but also mongodb, ftp, etc...

### DIFF
--- a/viewer/front/components/SlackMessage.js
+++ b/viewer/front/components/SlackMessage.js
@@ -43,7 +43,7 @@ export default class extends Component {
         .replace(/<@([0-9A-Za-z]+)>/gi, (m, id) => userLink(id))
         .replace(/<@([0-9A-Za-z]+)\|([0-9A-Za-z]+)>/gi, (m, id) => userLink(id))
         .replace(/<!(channel|everyone|group)>/gi, (m, command) => specialCommand(command))
-        .replace(/<(https?:\/\/[^>]*)>/gi, (m, uri) => uriLink(entity(uri)));
+        .replace(/<([a-z]+:\/\/[^>]*)>/gi, (m, uri) => uriLink(entity(uri)));
     }
     return text;
   }

--- a/viewer/front/components/SlackMessage.js
+++ b/viewer/front/components/SlackMessage.js
@@ -43,7 +43,7 @@ export default class extends Component {
         .replace(/<@([0-9A-Za-z]+)>/gi, (m, id) => userLink(id))
         .replace(/<@([0-9A-Za-z]+)\|([0-9A-Za-z]+)>/gi, (m, id) => userLink(id))
         .replace(/<!(channel|everyone|group)>/gi, (m, command) => specialCommand(command))
-        .replace(/<([a-z]+:\/\/[^>]*)>/gi, (m, uri) => uriLink(entity(uri)));
+        .replace(/<([a-z0-9]+:\/\/[^>]*)>/gi, (m, uri) => uriLink(entity(uri)));
     }
     return text;
   }


### PR DESCRIPTION
fix #88

slack sends raw text like `<https://...>`, but they also do the same with `<mongodb://...>`.
slack patron didn't display those links properly.