### PR TITLE
Fix a viewer error that occurs when AWS is not used.

### DIFF
--- a/viewer/viewer.rb
+++ b/viewer/viewer.rb
@@ -10,7 +10,7 @@ require './lib/db'
 $config = SlackPatronConfig.config
 $signer = nil
 
-if $config.has_key? :aws
+if $config[:aws]&.values.all?
   Aws.config.update({
     credentials: Aws::Credentials.new(
       $config[:aws][:access_key_id],


### PR DESCRIPTION
Even if AWS credentials config values are nil, `$config.has_key? :aws` returns true.
It might not be working as expected:
https://github.com/tyage/slack-patron/blob/c86c4777b9d2642c8171f19d07214aeb6d45b995/viewer/viewer.rb#L13-L22

Since `$singer` is not nil, `presigned_url` is called without AWS credentials set and throws `Aws::Sigv4::Errors::MissingCredentialsError`:
https://github.com/tyage/slack-patron/blob/c86c4777b9d2642c8171f19d07214aeb6d45b995/viewer/viewer.rb#L29-L56

I fixed this problem by correcting `$config.has_key? :aws` to `$config[:aws]&.values.all?`.